### PR TITLE
Use fenc for NeoVim

### DIFF
--- a/plugin/skk.vim
+++ b/plugin/skk.vim
@@ -4409,7 +4409,11 @@ function! s:SkkSearchBuf(buf, limit)
     if &enc != enc
       let key = iconv(key, &enc, enc)
       let l:enc_save = &enc
-      set enc=latin1
+      if has('nvim')
+        set fenc=latin1
+      else
+        set enc=latin1
+      endif
     endif
     if a:limit == 0
       let str = SkkSearchLinear(a:buf, key, okuri)
@@ -4511,7 +4515,11 @@ function! s:SkkCompSearch(first, key, flag)
     if buf[0][2] != &enc
       let key = iconv(key, &enc, buf[0][2])
       let l:enc_save = &enc
-      set enc=latin1
+      if has('nvim')
+        set fenc=latin1
+      else
+        set enc=latin1
+      endif
     endif
     let key = escape(key, '$.*\[]')
     let key = s:SkkGetCompKey(key) . '\m\C'


### PR DESCRIPTION
## 問題の再現手順
NeoVim v0.4.4、skk.vim master (https://github.com/tyru/skk.vim/commit/ce30e348f173935bff14555a82265adc86ee576e) をmacOSで使っています。AquaSKKの辞書を流用するため、

```vim
let g:skk_large_jisyo = '~/Library/Application Support/AquaSKK/SKK-JISYO.L'
```

という設定をいれていますが、変換の際 `set enc=latin1` のところで "Option not supported:set encoding=latin1" というエラーが出ます。 `let g:skk_large_jisyo_encoding = 'latin1'` も試してみましたが特に意味はありませんでした。

## 変更内容
NeoVimだとUTF-8固定になっておりencという設定がそもそもなく、かわりにfencを使うことになっているようです https://github.com/neovim/neovim/issues/6994 。このPRの修正をいれてからは問題なく変換できるようになりました。